### PR TITLE
Fix: Prevent self-peer detection by filtering own Nostr events

### DIFF
--- a/Sources/TrysteroSwift/NostrClient.swift
+++ b/Sources/TrysteroSwift/NostrClient.swift
@@ -198,6 +198,12 @@ class TrysteroNostrClient: NostrClientDelegate {
     }
     
     private func handleNostrEvent(_ event: Event, for roomId: String) {
+        // Skip our own events
+        guard event.pubkey != keyPair.publicKey else {
+            print("🔍 [Swift Debug] Ignoring our own event")
+            return
+        }
+        
         let expectedTopicHash = generateTopic(roomId: roomId)
         let expectedEventKind = calculateEventKind(for: roomId)
         


### PR DESCRIPTION
## Summary
- Added self-filtering logic to prevent peers from processing their own Nostr events
- Fixes issue where peers would attempt to connect to themselves via WebRTC
- Maintains existing functionality while preventing self-connections

## Test plan
- [x] Unit tests pass (PeerManagementTests, TrysteroTests, WebRTCManagerTests)
- [x] Core peer management functionality verified
- [x] Self-filtering logic confirmed in debug logs

🤖 Generated with [Claude Code](https://claude.ai/code)